### PR TITLE
Added compability for output filename control

### DIFF
--- a/nodes/hdbet/hdbet.py
+++ b/nodes/hdbet/hdbet.py
@@ -1,10 +1,12 @@
 from rhnode import RHNode
 from pydantic import BaseModel, FilePath
+from typing import Optional
 import subprocess
 import os
 
 class HDBetInput(BaseModel):
     mr:FilePath
+    out_file: Optional[str] = None
 
 class HDBetOutput(BaseModel):
     masked_mr:FilePath
@@ -20,8 +22,8 @@ class HDBetNode(RHNode):
 
     def process(inputs, job):
 
-        out_mri = job.directory / "mri_masked.nii.gz"
-        out_mask= job.directory / "mri_masked_mask.nii.gz"
+        out_mri = job.directory / inputs.out_file if inputs.out_file is not None else job.directory / os.path.basename(inputs.mr).replace('.nii.gz', '_BET.nii.gz')
+        out_mask= job.directory / (out_mri.name.replace('.nii.gz', '_mask.nii.gz'))
 
         cmd = ["hd-bet", "-i", str(inputs.mr), "-o", str(out_mri)]
 

--- a/nodes/hdbet/test_hdbet.py
+++ b/nodes/hdbet/test_hdbet.py
@@ -1,15 +1,33 @@
 from rhnode import RHJob
+import shutil, os
 
 data = {
     "mr": "/homes/hinge/Projects/rh-node/tests/data/mr.nii.gz"
 }
-
 node = RHJob(
     node_name="hdbet",
     inputs = data,
 )
-
 node.start()
-
 output = node.wait_for_finish()
 print(output)
+assert os.path.exists('hdbet/mr_BET.nii.gz')
+assert os.path.exists('hdbet/mr_BET_mask.nii.gz')
+shutil.rmtree('hdbet', ignore_errors=True)
+
+
+
+data = {
+    "mr": "/homes/hinge/Projects/rh-node/tests/data/mr.nii.gz",
+    "out_file": "MRI_bet.nii.gz"
+}
+node = RHJob(
+    node_name="hdbet",
+    inputs = data,
+)
+node.start()
+output = node.wait_for_finish()
+print(output)
+assert os.path.exists('hdbet/MRI_bet.nii.gz')
+assert os.path.exists('hdbet/MRI_bet_mask.nii.gz')
+shutil.rmtree('hdbet', ignore_errors=True)

--- a/nodes/hdctbet/hdctbet.py
+++ b/nodes/hdctbet/hdctbet.py
@@ -2,9 +2,12 @@ from rhnode import RHNode
 from pydantic import BaseModel, FilePath
 import subprocess
 import os
+from typing import Optional
+
 
 class HDCTBetInput(BaseModel):
     ct:FilePath
+    out_file: Optional[str] = None
 
 class HDCTBetOutput(BaseModel):
     masked_ct:FilePath
@@ -20,8 +23,8 @@ class HDCTBetNode(RHNode):
 
     def process(inputs, job):
 
-        out_ct = job.directory / "ct_masked.nii.gz"
-        out_mask= job.directory / "ct_masked_mask.nii.gz"
+        out_ct = job.directory / inputs.out_file if inputs.out_file is not None else job.directory / os.path.basename(inputs.ct).replace('.nii.gz', '_BET.nii.gz')
+        out_mask= job.directory / (out_ct.name.replace('.nii.gz', '_mask.nii.gz'))
 
         cmd = ["hd-ctbet", "-i", str(inputs.ct), "-o", str(out_ct)]
 

--- a/nodes/hdctbet/test_hdctbet.py
+++ b/nodes/hdctbet/test_hdctbet.py
@@ -1,16 +1,32 @@
 from rhnode import RHJob
+import os, shutil
 
 # Inputs to HDCTBET
 data = {
     "ct": "/homes/claes/projects/CTBET/imagesTs/FET_004_0000.nii.gz"
 }
-
 node = RHJob(
     node_name="hdctbet",
     inputs = data,
 )
-
 node.start()
-
 output = node.wait_for_finish()
 print(output)
+assert os.path.exists('hdctbet/FET_004_0000_BET.nii.gz')
+assert os.path.exists('hdctbet/FET_004_0000_BET_mask.nii.gz')
+shutil.rmtree('hdctbet', ignore_errors=True)
+
+data = {
+    "ct": "/homes/claes/projects/CTBET/imagesTs/FET_004_0000.nii.gz",
+    "out_file": "CT_bet.nii.gz"
+}
+node = RHJob(
+    node_name="hdctbet",
+    inputs = data,
+)
+node.start()
+output = node.wait_for_finish()
+print(output)
+assert os.path.exists('hdctbet/CT_bet.nii.gz')
+assert os.path.exists('hdctbet/CT_bet_mask.nii.gz')
+shutil.rmtree('hdctbet', ignore_errors=True)


### PR DESCRIPTION
hdbet and hdctbet can now be called with `-out_file <name.nii.gz>` which controls the output filename.
In addition, the default filename is now not mr_masked.nii (or ct_..) but <input>_BET.nii.gz> and <input>_BET_mask.nii.gz for files named <input>.nii.gz