### PR TITLE
removed fsl tools from workflow

### DIFF
--- a/.github/workflows/docker_build_and_push.yml
+++ b/.github/workflows/docker_build_and_push.yml
@@ -27,12 +27,6 @@ jobs:
           elif [[ "$VAL" == amyloidai-* ]]; then
             echo "::set-output name=dir::nodes/amyloidAI"
             echo "::set-output name=image_name::amyloidai"
-          elif [[ "$VAL" == reorient2std-* ]]; then
-            echo "::set-output name=dir::nodes/reorient2std"
-            echo "::set-output name=image_name::reorient2std"
-          elif [[ "$VAL" == flirt-* ]]; then
-            echo "::set-output name=dir::nodes/flirt"
-            echo "::set-output name=image_name::flirt"
           elif [[ "$VAL" == aims-* ]]; then
             echo "::set-output name=dir::nodes/aims"
             echo "::set-output name=image_name::aims"

--- a/nodes/flirt/docker-compose.yaml
+++ b/nodes/flirt/docker-compose.yaml
@@ -33,6 +33,7 @@ services:
       RH_NUM_THREADS: 6
 
   flirt:
+    image: rhnode/flirt:v0.1.0_rhnode1.2.0a.1
     build: .
     deploy:
       resources:

--- a/nodes/reorient2std/docker-compose.yaml
+++ b/nodes/reorient2std/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
       RH_NUM_THREADS: 6
 
   reorient2std:
+    image: rhnode/reorient2std:v0.1.0_rhnode1.1.1
     build: .
     deploy:
       resources:


### PR DESCRIPTION
FSL was too large to build on github. Instead, manually tag version is added to the docker compose files, and the containers are manually pushed to docker hub.